### PR TITLE
feat: show user name in webauthn dialog

### DIFF
--- a/library.js
+++ b/library.js
@@ -89,10 +89,11 @@ plugin.addRoutes = async ({ router, middleware, helpers }) => {
 
 	routeHelpers.setupApiRoute(router, 'get', '/2factor/authn/register', middlewares, async (req, res) => {
 		const registrationRequest = await plugin._f2l.attestationOptions();
+		const userData = await user.getUserFields(req.uid, ['username', 'displayname']);
 		registrationRequest.user = {
 			id: base64url(String(req.uid)),
-			name: 'foobar',
-			displayName: 'foobar',
+			name: userData.username,
+			displayName: userData.displayname,
 		};
 		registrationRequest.challenge = base64url(registrationRequest.challenge);
 		req.session.registrationRequest = registrationRequest;


### PR DESCRIPTION
One user was confused by the foobar in the dialog box when logging in. Changed it so it uses the actual username for webauthn.