### PR TITLE
Switch deprecated @github/webauthn-json package to browser methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "compatibility": "^4.0.0"
   },
   "dependencies": {
-    "@github/webauthn-json": "^0.5.7",
     "arraybuffer-to-string": "^1.0.2",
     "async": "^3.2.0",
     "base64url": "^3.0.1",

--- a/static/lib/authn.js
+++ b/static/lib/authn.js
@@ -5,13 +5,12 @@ define('forum/login-authn', ['api', 'alerts', 'hooks'], function (api, alerts, h
 
 	Plugin.init = async () => {
 		try {
-			const webauthnJSON = await import('@github/webauthn-json');
 			const abortController = new AbortController();
 			hooks.on('action:ajaxify.start', () => {
 				abortController.abort();
 			});
 
-			const authResponse = await webauthnJSON.get({
+			const authResponse = await navigator.credentials.get({
 				publicKey: ajaxify.data.authnOptions,
 				signal: abortController.signal,
 			});

--- a/static/lib/settings.js
+++ b/static/lib/settings.js
@@ -69,8 +69,7 @@ define('forum/account/2factor', ['api', 'alerts', 'bootbox'], function (api, ale
 		});
 		api.get('/plugins/2factor/authn/register', {}).then(async (request) => {
 			try {
-				const webauthnJSON = await import('@github/webauthn-json');
-				const response = await webauthnJSON.create({
+				const response = await navigator.credentials.create({
 					publicKey: request,
 				});
 				modal.modal('hide');


### PR DESCRIPTION
The `@github/webauthn-json` package was deprecated last year, with the developers recommending the use of built-in browser methods in its place, so I removed the package from the dependencies list and dropped in the equivalent `navigator.credentials` methods. The package developers say that the browser methods can be used as drop-in replacements since the package's functions were wrappers around those methods, so switching to them should result in no changes for users, especially as the methods have been supported by all major browsers since around 2018-2019.

I tested the plugin changes by attempting to authenticate using 2FA on my local instance, and the plugin worked as expected. I also ran the `npm test` suite from the head of the main NodeBB repo before and after making the plugin changes, which resulted in a few more tests passing for me locally but no major differences otherwise.

Source for the drop-in nature of the browser methods:
https://github.com/github/webauthn-json#reasoning

Browser compatibility:
https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create#browser_compatibility
https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/get#browser_compatibility

Package wrapper functions references:
https://github.com/github/webauthn-json/blob/v0.5.7/src/basic/api.ts#L35
https://github.com/github/webauthn-json/blob/v0.5.7/src/basic/api.ts#L62