### PR TITLE
fix: drop hardcoded `transports` from allowCredentials (Bitwarden passkeys broken since extension 2026.6.0)

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -125,7 +125,10 @@ Controllers.renderAuthnChallenge = async (req, res, next) => {
 		authnOptions.allowCredentials = devices.map(d => ({
 			id: d.id,
 			type: 'public-key',
-			transports: ['usb', 'ble', 'nfc'],
+			// Note: `transports` intentionally omitted. It is an optional routing
+			// hint; restricting it to usb/ble/nfc hides credentials that browsers
+			// surface via the platform/internal/hybrid path (e.g. Bitwarden,
+			// passkey providers), locking those users out of the challenge.
 		}));
 		authnOptions.challenge = base64url(authnOptions.challenge);
 		req.session.authRequest = authnOptions.challenge;

--- a/static/lib/authn.js
+++ b/static/lib/authn.js
@@ -94,7 +94,7 @@ define('forum/login-authn', ['api', 'alerts', 'hooks'], function (api, alerts, h
 				const selectedId = deviceSelect.value;
 				authBtn.disabled = true;
 				try {
-					await Plugin.verify([{ id: selectedId, type: 'public-key', transports: ['usb', 'ble', 'nfc'] }], (next) => {
+					await Plugin.verify([{ id: selectedId, type: 'public-key' }], (next) => {
 						document.location = next;
 					});
 				} catch (e) {


### PR DESCRIPTION
Fixes #122

### Problem

The WebAuthn challenge declares every registered credential as `transports: ['usb', 'ble', 'nfc']`, both server-side ([lib/controllers.js#L128](https://github.com/NodeBB/nodebb-plugin-2factor/blob/cfce6ccd7f2b511b4960e4180d79134e67653c25/lib/controllers.js#L128)) and in the multi-device client path ([static/lib/authn.js#L97](https://github.com/NodeBB/nodebb-plugin-2factor/blob/cfce6ccd7f2b511b4960e4180d79134e67653c25/static/lib/authn.js#L97)).

Bitwarden passkeys are `["internal", "hybrid"]`, and since [bitwarden/clients#19606](https://github.com/bitwarden/clients/pull/19606) (browser extension 2026.6.0, released 2026-06-25) the extension refuses any assertion request in which every `allowCredentials` entry declares non-`internal` transports only — it falls back to the browser's native hardware-key dialog. With this plugin that condition is always true, so Bitwarden never offers the passkey and the second-factor challenge cannot be completed. Users whose only second factor is a Bitwarden passkey are locked out.

Bitwarden explicitly treats this as an RP bug (from the PR description: *"if an RP does not send correct transports a Bitwarden passkey would not be usable, but this is accepted as an RP issue"*), so it has to be fixed here.

### Fix

Omit the `transports` member. It is an optional hint; per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports) it should either be the stored `getTransports()` value from registration or left out — never an invented fixed list. Without the hint the browser considers all transports, so Bitwarden/platform passkeys work again and hardware keys (usb/ble/nfc) keep working as before. Since transports were never stored per device, omission also fixes all already-registered credentials without migration.

**Security:** no change. `transports` is a routing hint with no security semantics — it is not part of the signed data and nothing verifies it. Challenge, origin, signature, credential ownership and counter checks in fido2-lib's `assertionResult()` are untouched; this only changes which authenticators the browser *offers*, not what the server *accepts*.

### Testing

Tested against NodeBB v4.14.0:

- Before: on `/login/2fa/authn`, Bitwarden (extension 2026.6.0+) never prompts; the browser opens its native security-key dialog and login is impossible without a hardware key. Same behaviour on Chrome, Chromium, Brave and Firefox.
- After (patched plugin): Bitwarden offers the stored passkey on the challenge page and login completes.
- Hardware keys: not re-tested here, but behaviour is expected unchanged — the hint is optional and browsers probe usb/nfc regardless when it is absent.
