### PR TITLE
Fix: disabling WebAuthn 404s — DELETE /2factor/authn is not registered

### DIFF
--- a/library.js
+++ b/library.js
@@ -153,6 +153,11 @@ plugin.addRoutes = async ({ router, middleware, helpers }) => {
 		helpers.formatApiResponse(200, res);
 	});
 
+	routeHelpers.setupApiRoute(router, 'delete', '/2factor/authn', middlewares, async (req, res) => {
+		await plugin.removeAllDevices(req.uid);
+		helpers.formatApiResponse(200, res);
+	});
+
 	routeHelpers.setupApiRoute(router, 'post', '/2factor/authn/register', middlewares, async (req, res) => {
 		const attestationExpectations = {
 			challenge: req.session.registrationRequest.challenge,
@@ -392,6 +397,10 @@ plugin.disassociate = async (uid) => {
 	]);
 
 	// Clear U2F keys
+	await plugin.removeAllDevices(uid);
+};
+
+plugin.removeAllDevices = async (uid) => {
 	const keyIds = await db.getObjectKeys(`2factor:webauthn:${uid}`);
 	await db.sortedSetRemove('2factor:webauthn:counters', keyIds);
 	await db.delete(`2factor:webauthn:${uid}`);


### PR DESCRIPTION
The **Disable** button on the account 2factor page (`static/templates/account/2factor.tpl`, `data-action="disableAuthn"`) calls `api.del('/plugins/2factor/authn')`, but only `/2factor/authn/register`, `/devices`, `/device`, `/device/:id` and `/verify` are registered — there is no bare `DELETE /2factor/authn`. The request 404s and users cannot remove WebAuthn wholesale.

This registers the missing route, backed by a new `plugin.removeAllDevices(uid)` helper that clears all WebAuthn keys, their names, and their counters for the user. `plugin.disassociate` previously inlined the same key-clearing logic and now reuses the helper.